### PR TITLE
Allow adr template to be stored locally instead of using a Nuget Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,15 @@ Then:
 
 `adr templates install`
 
+#### Store template file locally
+Optionally, store the template file file inside the repository, and specify the TemplatePath in the `adr.config.json` file.
+
+```json
+{
+    "templatePath": "./Docs/adr-template.md"
+}
+```
+
 ## Local System Details
 
 `adr` stores various configuration files and packages in an application profile folder created in:

--- a/Solutions/Endjin.Adr.Cli/Configuration/AdrConfig.cs
+++ b/Solutions/Endjin.Adr.Cli/Configuration/AdrConfig.cs
@@ -7,4 +7,6 @@ namespace Endjin.Adr.Cli.Configuration;
 public class AdrConfig
 {
     public string Path { get; set; }
+
+    public string TemplatePath { get; set; }
 }


### PR DESCRIPTION
This PR introduces a usability improvement to by allowing users to specify custom ADR templates directly through the adr.config.json file, as an alternative to the Nuget package package workflow.