### PR TITLE
Allow the inclusion of a {DATE} placeholder in the template files

### DIFF
--- a/Solutions/Endjin.Adr.Cli/Commands/New/NewAdrCommand.cs
+++ b/Solutions/Endjin.Adr.Cli/Commands/New/NewAdrCommand.cs
@@ -135,7 +135,9 @@ public partial class NewAdrCommand : AsyncCommand<NewAdrCommand.Settings>
 
         Regex yamlHeaderRegExp = YamlHeaderRegex();
 
-        return yamlHeaderRegExp.Replace(templateContents, $"# {title}");
+        return yamlHeaderRegExp
+            .Replace(templateContents, $"# {title}")
+            .Replace("{DATE}", DateTime.Now.ToShortDateString());
     }
 
     private static async Task<List<Adr>> GetAllAdrFilesFromCurrentDirectoryAsync(string targetPath)


### PR DESCRIPTION
The {DATE} placeholder will be replaced by the current Date when a new ADR is created, using the users locale.