### PR TITLE
Allow the inclusion of a {TITLE} placeholder in the template files

### DIFF
--- a/Solutions/Endjin.Adr.Cli/Commands/New/NewAdrCommand.cs
+++ b/Solutions/Endjin.Adr.Cli/Commands/New/NewAdrCommand.cs
@@ -141,7 +141,8 @@ public partial class NewAdrCommand : AsyncCommand<NewAdrCommand.Settings>
 
         return yamlHeaderRegExp
             .Replace(templateContents, $"# {title}")
-            .Replace("{DATE}", DateTime.Now.ToShortDateString());
+            .Replace("{DATE}", DateTime.Now.ToShortDateString())
+            .Replace("{TITLE}", title);
     }
 
     private static async Task<List<Adr>> GetAllAdrFilesFromCurrentDirectoryAsync(string targetPath)


### PR DESCRIPTION
The `{TITLE}` placeholder is replaced with the title when a new ADR is created.